### PR TITLE
fix: avoid G115 integer overflow in payload cache init

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -39,7 +39,7 @@ func init() {
 	src := rand.New(rand.NewPCG(0, 0))
 	payloadCache = make([]byte, 1<<20) // 1MB
 	for i := range payloadCache {
-		payloadCache[i] = byte(src.IntN(256)) // Random bytes (0-255)
+		payloadCache[i] = byte(src.Uint32() & 0xFF) // Random bytes (0-255)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes gosec alert [#32](https://github.com/PhilipSchmid/flow-generator-app/security/code-scanning/32): **G115 (CWE-190) — integer overflow conversion `int` → `byte`**.

## Root Cause

In `cmd/client/main.go`, the payload cache was initialized using:

```go
payloadCache[i] = byte(src.IntN(256)) // Random bytes (0-255)
```

`src.IntN(256)` returns an `int`. Even though the value is always in `[0, 255]`, gosec G115 flags the explicit narrowing conversion from `int` to `byte` as a potential integer overflow.

## Fix

Replace with `src.Uint32() & 0xFF`, which returns a `uint32` masked to the lower 8 bits. The `uint32 → byte` narrowing is safe and not flagged by gosec:

```go
payloadCache[i] = byte(src.Uint32() & 0xFF) // Random bytes (0-255)
```

## Verification

- `gosec -severity medium ./...` → **0 issues**
- `go build ./...` → clean
- `go test ./...` → all tests pass