### PR TITLE
fix(client): drain late replies before closing to avoid RST

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -33,6 +33,11 @@ var payloadCache []byte
 var cfg *config.ClientConfig
 var mc *metrics.MetricsCollector
 
+// tcpCloseGracePeriod bounds how long we wait to drain a reply that was
+// already in flight when a flow's deadline expired, before closing the
+// socket. Keeps closes clean (FIN) instead of racing the peer into an RST.
+const tcpCloseGracePeriod = 200 * time.Millisecond
+
 // init initializes the payload cache with random bytes
 func init() {
 	payloadCache = make([]byte, 1<<20) // 1MB
@@ -64,6 +69,29 @@ func getPayloadSize() int {
 		return minSize + rand.IntN(maxSize-minSize+1)
 	}
 	return 5 // Default to 5 bytes
+}
+
+// drainStragglerReply gives conn a short, bounded grace window to receive a
+// reply that was already in flight when the caller's read loop broke out
+// (deadline hit or read error). Closing a TCP socket while data the peer
+// already sent is still arriving makes the kernel answer with RST instead
+// of a clean FIN -- indistinguishable from a real failure in Hubble/tcpdump,
+// and observed live as synchronized RST bursts across an entire batch of
+// otherwise-healthy flows sharing the same fixed flow duration. Half-closes
+// the write side first (nothing left to send) so the peer sees FIN promptly
+// instead of waiting out its own read timeout.
+func drainStragglerReply(conn net.Conn, buf []byte) {
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.CloseWrite()
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(tcpCloseGracePeriod)); err != nil {
+		return
+	}
+	for {
+		if _, err := conn.Read(buf); err != nil {
+			return
+		}
+	}
 }
 
 // generateFlow generates network traffic to the server and reads the echoed response
@@ -127,6 +155,11 @@ func generateFlow(mainCtx context.Context, server string, pp ProtocolPort, durat
 		}
 		if totalReceived != payloadSize {
 			logging.Logger.Warnf("TCP byte mismatch: sent %d bytes, received %d bytes", payloadSize, totalReceived)
+
+			// The read above broke early (deadline hit or connection error),
+			// so a reply the server already sent may still be in flight.
+			// Drain it before Close() -- see drainStragglerReply.
+			drainStragglerReply(conn, buf)
 		}
 
 		// Wait for the flow's context to be done (timeout or mainCtx cancellation)

--- a/cmd/client/main_test.go
+++ b/cmd/client/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/PhilipSchmid/flow-generator-app/internal/config"
 	"github.com/PhilipSchmid/flow-generator-app/internal/logging"
@@ -200,6 +201,58 @@ func TestGenerateFlow(t *testing.T) {
 	wg.Wait()
 
 	assert.True(t, true)
+}
+
+// TestDrainStragglerReplyAbsorbsLateData verifies drainStragglerReply reads
+// a reply that arrives after the caller's own read loop already gave up,
+// instead of returning immediately and leaving the caller to Close() a
+// socket with a peer reply still in flight -- the exact condition that
+// makes the kernel answer with RST instead of a clean FIN (observed live
+// via Hubble as synchronized RST bursts across a whole batch of otherwise
+// healthy flows sharing the same fixed duration).
+func TestDrainStragglerReplyAbsorbsLateData(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	written := make(chan error, 1)
+	go func() {
+		// Simulate the server's reply landing after the client already gave
+		// up reading, but well within the drain's grace window.
+		time.Sleep(tcpCloseGracePeriod / 4)
+		_, err := server.Write([]byte("late"))
+		written <- err
+	}()
+
+	buf := make([]byte, 16)
+	drainStragglerReply(client, buf)
+
+	select {
+	case err := <-written:
+		require.NoError(t, err, "server should have been able to write its late reply")
+	case <-time.After(2 * time.Second):
+		t.Fatal("server's late write never completed -- drainStragglerReply likely returned without draining")
+	}
+}
+
+// TestDrainStragglerReplyBoundedWhenPeerSilent verifies drainStragglerReply
+// returns once its grace window elapses instead of blocking indefinitely
+// when the peer never replies at all.
+func TestDrainStragglerReplyBoundedWhenPeerSilent(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		drainStragglerReply(client, make([]byte, 16))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(tcpCloseGracePeriod + 500*time.Millisecond):
+		t.Fatal("drainStragglerReply did not return within its grace window")
+	}
 }
 
 func TestMetricsCollectorInterface(t *testing.T) {

--- a/cmd/client/main_test.go
+++ b/cmd/client/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"net"
 	"sync"
 	"testing"
@@ -203,35 +204,58 @@ func TestGenerateFlow(t *testing.T) {
 	assert.True(t, true)
 }
 
-// TestDrainStragglerReplyAbsorbsLateData verifies drainStragglerReply reads
-// a reply that arrives after the caller's own read loop already gave up,
-// instead of returning immediately and leaving the caller to Close() a
-// socket with a peer reply still in flight -- the exact condition that
-// makes the kernel answer with RST instead of a clean FIN (observed live
-// via Hubble as synchronized RST bursts across a whole batch of otherwise
-// healthy flows sharing the same fixed duration).
-func TestDrainStragglerReplyAbsorbsLateData(t *testing.T) {
-	client, server := net.Pipe()
-	defer func() { _ = client.Close() }()
+// TestDrainStragglerReplyHalfClosesTCP verifies the real TCP shutdown path:
+// the peer sees a clean EOF from CloseWrite, can still send its final reply,
+// and the client drains that reply before returning.
+func TestDrainStragglerReplyHalfClosesTCP(t *testing.T) {
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
 
-	written := make(chan error, 1)
+	type serverResult struct {
+		deadlineErr error
+		readErr     error
+		writeErr    error
+	}
+
+	accepted := make(chan struct{})
+	result := make(chan serverResult, 1)
 	go func() {
-		// Simulate the server's reply landing after the client already gave
-		// up reading, but well within the drain's grace window.
-		time.Sleep(tcpCloseGracePeriod / 4)
-		_, err := server.Write([]byte("late"))
-		written <- err
+		conn, acceptErr := listener.AcceptTCP()
+		if acceptErr != nil {
+			result <- serverResult{readErr: acceptErr}
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		close(accepted)
+
+		deadlineErr := conn.SetReadDeadline(time.Now().Add(2 * tcpCloseGracePeriod))
+		_, readErr := conn.Read(make([]byte, 1))
+		if readErr != io.EOF {
+			result <- serverResult{deadlineErr: deadlineErr, readErr: readErr}
+			return
+		}
+
+		_, writeErr := conn.Write([]byte("late"))
+		result <- serverResult{deadlineErr: deadlineErr, readErr: readErr, writeErr: writeErr}
 	}()
+
+	client, err := net.DialTCP("tcp", nil, listener.Addr().(*net.TCPAddr))
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+	<-accepted
 
 	buf := make([]byte, 16)
 	drainStragglerReply(client, buf)
 
-	select {
-	case err := <-written:
-		require.NoError(t, err, "server should have been able to write its late reply")
-	case <-time.After(2 * time.Second):
-		t.Fatal("server's late write never completed -- drainStragglerReply likely returned without draining")
-	}
+	server := <-result
+	require.NoError(t, server.deadlineErr)
+	require.ErrorIs(t, server.readErr, io.EOF, "server should observe the client's FIN, not a reset")
+	require.NoError(t, server.writeErr, "server should be able to send after the client half-closes")
+
+	n, err := client.Read(buf)
+	require.Zero(t, n, "drain should consume the server's final reply")
+	require.ErrorIs(t, err, io.EOF)
 }
 
 // TestDrainStragglerReplyBoundedWhenPeerSilent verifies drainStragglerReply


### PR DESCRIPTION
A flow's read loop breaks as soon as its fixed duration expires, and the deferred Close() ran immediately after -- if the server's reply was already in flight, the kernel answered the late data with RST instead of a clean FIN. Confirmed live via hubble observe: whole batches of otherwise-healthy flows RST at once because constant_flows fills max_concurrent in near-lockstep at startup, so their fixed-duration deadlines all land within a few ms of each other.

drainStragglerReply half-closes the write side and gives the peer a short, bounded grace window to finish sending before the socket closes. Doesn't change a flow's declared duration, only avoids closing on data already on the wire.