### PR TITLE
Reject non-finite flow rates

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"strconv"
@@ -100,6 +101,9 @@ func (c *ClientConfig) Validate() error {
 		return fmt.Errorf("server address cannot be empty")
 	}
 
+	if math.IsNaN(c.Rate) || math.IsInf(c.Rate, 0) {
+		return fmt.Errorf("rate must be finite")
+	}
 	if c.Rate <= 0 {
 		return fmt.Errorf("rate must be positive")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"math"
 	"os"
 	"testing"
 
@@ -134,6 +135,45 @@ func TestClientConfigValidate(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "server address cannot be empty",
+		},
+		{
+			name: "NaN rate",
+			config: ClientConfig{
+				CommonConfig: CommonConfig{
+					LogLevel:  "info",
+					LogFormat: "json",
+				},
+				Server: "localhost",
+				Rate:   math.NaN(),
+			},
+			wantErr: true,
+			errMsg:  "rate must be finite",
+		},
+		{
+			name: "positive infinite rate",
+			config: ClientConfig{
+				CommonConfig: CommonConfig{
+					LogLevel:  "info",
+					LogFormat: "json",
+				},
+				Server: "localhost",
+				Rate:   math.Inf(1),
+			},
+			wantErr: true,
+			errMsg:  "rate must be finite",
+		},
+		{
+			name: "negative infinite rate",
+			config: ClientConfig{
+				CommonConfig: CommonConfig{
+					LogLevel:  "info",
+					LogFormat: "json",
+				},
+				Server: "localhost",
+				Rate:   math.Inf(-1),
+			},
+			wantErr: true,
+			errMsg:  "rate must be finite",
 		},
 		{
 			name: "negative rate",


### PR DESCRIPTION
## Summary

- reject NaN and infinite rates before scheduler interval calculation
- cover NaN and both infinity signs

## Testing

- full Go test suite with the race detector
- golangci-lint
- real client invocation with --rate NaN